### PR TITLE
fix(factory): define "sandbox" by default, remote it from required options

### DIFF
--- a/src/SystemPayGatewayFactory.php
+++ b/src/SystemPayGatewayFactory.php
@@ -38,7 +38,7 @@ class SystemPayGatewayFactory extends GatewayFactory
                 Api::FIELD_VADS_PAGE_ACTION       => Api::PAGE_ACTION_PAYMENT,
                 Api::FIELD_VADS_PAYMENT_CONFIG    => Api::PAYMENT_CONFIG_SINGLE,
                 Api::FIELD_VADS_VERSION           => Api::V2,
-                'sandbox'                         => null,
+                'sandbox'                         => true,
                 'certif_prod'                     => null,
                 'certif_test'                     => null,
             ];
@@ -47,7 +47,6 @@ class SystemPayGatewayFactory extends GatewayFactory
                 Api::FIELD_VADS_SITE_ID,
                 Api::FIELD_VADS_ACTION_MODE,
                 Api::FIELD_VADS_PAGE_ACTION,
-                'sandbox',
                 'certif_test',
                 'certif_prod',
             ];

--- a/tests/SystemPayGatewayFactoryTest.php
+++ b/tests/SystemPayGatewayFactoryTest.php
@@ -22,7 +22,7 @@ class SystemPayGatewayFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage The vads_site_id, sandbox, certif_test, certif_prod fields are required.
+     * @expectedExceptionMessage The vads_site_id, certif_test, certif_prod fields are required.
      */
     public function shouldThrowIfRequiredOptionsAreNotPassed()
     {
@@ -55,14 +55,13 @@ class SystemPayGatewayFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('PAYMENT', $config['payum.default_options']['vads_page_action']);
         $this->assertSame('SINGLE', $config['payum.default_options']['vads_payment_config']);
         $this->assertSame('V2', $config['payum.default_options']['vads_version']);
-        $this->assertNull($config['payum.default_options']['sandbox']);
+        $this->assertTrue($config['payum.default_options']['sandbox']);
         $this->assertNull($config['payum.default_options']['certif_prod']);
         $this->assertNull($config['payum.default_options']['certif_test']);
         $this->assertEquals([
             'vads_site_id',
             'vads_action_mode',
             'vads_page_action',
-            'sandbox',
             'certif_test',
             'certif_prod',
         ], $config['payum.required_options']);


### PR DESCRIPTION
Sinon lorsqu'on décoche le mode de test sur Condictio, on a l'erreur `The options sandbox are required` vu que `sandbox` vaut `false`.

J'ai fait ce qui a été fait pour les gateways : 
  - PayPal : https://github.com/Payum/Payum/blob/master/src/Payum/Paypal/ExpressCheckout/Nvp/PaypalExpressCheckoutGatewayFactory.php#L80-L83
  - Skeleton : https://github.com/Payum/Payum/blob/master/src/Payum/Skeleton/SkeletonGatewayFactory.php#L35-L38

J'ai vraiment troll pour le coup 