### PR TITLE
feat: introduce SignatureAlgorithm 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## 2.0.0
+
+### BREAKING CHANGES
+
+- Public constant `Yproximite\Payum\SystemPay\SignatureGenerator::HASH_ALGORITHM_PREFIX` does not exist anymore, use `Yproximite\Payum\SystemPaym\SignatureAlgorithm::toPayumOption(string $algo)` instead.
+
+## 1.1.0
+
+### Features
+
+- Add HMAC-SHA-256 hash algorithm support ([#20](https://github.com/Yproximite/payum-system-pay/pull/20))
+
+## 1.0.2
+
+### Fixes
+
+- Fix "sandbox" default option ([#16](https://github.com/Yproximite/payum-system-pay/pull/16))
+
+## 1.0.1
+
+### Fixes
+
+- Fix redirection when cancelling payment ([#15](https://github.com/Yproximite/payum-system-pay/pull/15))
+
+## 1.0.0
+
+Initial release! :tada:

--- a/src/Api.php
+++ b/src/Api.php
@@ -296,14 +296,7 @@ class Api
 
     protected function getHashAlgorithm(): string
     {
-        $hash = $this->options['hash_algorithm'];
-
-        // workaround for https://github.com/Payum/Payum/issues/692
-        if (SignatureGenerator::HASH_ALGORITHM_PREFIX === substr($hash, 0, $length = strlen(SignatureGenerator::HASH_ALGORITHM_PREFIX))) {
-            $hash = substr($hash, $length);
-        }
-
-        return $hash;
+        return SignatureAlgorithm::fromPayumOption($this->options['hash_algorithm']);
     }
 
     /**

--- a/src/SignatureAlgorithm.php
+++ b/src/SignatureAlgorithm.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yproximite\Payum\SystemPay;
+
+class SignatureAlgorithm
+{
+    public const SHA1        = 'sha1';
+    public const HMAC_SHA256 = 'hmac-sha256';
+    public const ALL         = [
+        self::SHA1,
+        self::HMAC_SHA256,
+    ];
+
+    // changing this value = breaking change
+    protected const HASH_ALGORITHM_PREFIX = 'algo-';
+
+    public static function toPayumOption(string $algo): string
+    {
+        if (self::HASH_ALGORITHM_PREFIX === substr($algo, 0, $length = strlen(self::HASH_ALGORITHM_PREFIX))) {
+            throw new \InvalidArgumentException(sprintf('The prefix "%s" is already present in passed algorithm "%s".', self::HASH_ALGORITHM_PREFIX, $algo));
+        }
+
+        if (!in_array($algo, self::ALL, true)) {
+            throw new \InvalidArgumentException(sprintf('Unknown algorithm "%s".', $algo));
+        }
+
+        $algo = self::HASH_ALGORITHM_PREFIX.$algo;
+
+        return $algo;
+    }
+
+    public static function fromPayumOption(string $algo): string
+    {
+        // workaround for https://github.com/Payum/Payum/issues/692
+        if (self::HASH_ALGORITHM_PREFIX === substr($algo, 0, $length = strlen(self::HASH_ALGORITHM_PREFIX))) {
+            $algo = substr($algo, $length);
+
+            if (!in_array($algo, self::ALL, true)) {
+                throw new \InvalidArgumentException(sprintf('Unknown algorithm "%s".', $algo));
+            }
+
+            return $algo;
+        }
+
+        throw new \InvalidArgumentException(sprintf('The prefix "%s" is not present in passed algorithm "%s".', self::HASH_ALGORITHM_PREFIX, $algo));
+    }
+}

--- a/src/SignatureGenerator.php
+++ b/src/SignatureGenerator.php
@@ -6,9 +6,7 @@ namespace Yproximite\Payum\SystemPay;
 
 class SignatureGenerator
 {
-    public const HASH_ALGORITHM_PREFIX = 'algo-';
-
-    public function generate(array $fields, string $certificate, string $hashAlgorithm = 'sha1'): string
+    public function generate(array $fields, string $certificate, string $hashAlgorithm = SignatureAlgorithm::SHA1): string
     {
         // Filter keys
         $fields = array_filter($fields, function ($key) {
@@ -24,9 +22,9 @@ class SignatureGenerator
         // Join fields values
         $str = implode('+', array_values($fields));
 
-        if ('sha1' === $hashAlgorithm) {
+        if (SignatureAlgorithm::SHA1 === $hashAlgorithm) {
             return sha1($str);
-        } elseif ('hmac-sha256' === $hashAlgorithm) {
+        } elseif (SignatureAlgorithm::HMAC_SHA256 === $hashAlgorithm) {
             return base64_encode(hash_hmac('sha256', $str, $certificate, true));
         }
 

--- a/src/SystemPayGatewayFactory.php
+++ b/src/SystemPayGatewayFactory.php
@@ -45,7 +45,7 @@ class SystemPayGatewayFactory extends GatewayFactory
                 // Due to a limitation of Payum (https://github.com/Payum/Payum/issues/692),
                 // the algorithm hash can not be "sha1" because it's a callable and will make Payum fails.
                 // As a workaround, we prefix the algorithm hash by something and it's not seen a callable anymore.
-                'hash_algorithm' => SignatureGenerator::HASH_ALGORITHM_PREFIX.'sha1',
+                'hash_algorithm' => SignatureAlgorithm::toPayumOption(SignatureAlgorithm::SHA1),
             ];
             $config->defaults($config['payum.default_options']);
             $config['payum.required_options'] = [

--- a/tests/SignatureAlgorithmTest.php
+++ b/tests/SignatureAlgorithmTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Yproximite\Payum\SystemPay\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Yproximite\Payum\SystemPay\SignatureAlgorithm;
+
+class SignatureAlgorithmTest extends TestCase
+{
+    public function testAlgos(): void
+    {
+        static::assertEquals('sha1', SignatureAlgorithm::SHA1);
+        static::assertEquals('hmac-sha256', SignatureAlgorithm::HMAC_SHA256);
+        static::assertEquals([SignatureAlgorithm::SHA1, SignatureAlgorithm::HMAC_SHA256], SignatureAlgorithm::ALL);
+    }
+
+    public function testToPayumOptionSuccess(): void
+    {
+        static::assertEquals('algo-sha1', SignatureAlgorithm::toPayumOption(SignatureAlgorithm::SHA1));
+        static::assertEquals('algo-hmac-sha256', SignatureAlgorithm::toPayumOption(SignatureAlgorithm::HMAC_SHA256));
+    }
+
+    public function testToPayumOptionFailAlreadyPrefixedAlgo(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The prefix "algo-" is already present in passed algorithm "algo-sha1".');
+
+        SignatureAlgorithm::toPayumOption('algo-'.SignatureAlgorithm::SHA1);
+    }
+
+    public function testToPayumOptionFailWithUnknownAlgo(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown algorithm "foobar".');
+
+        SignatureAlgorithm::toPayumOption('foobar');
+    }
+
+    public function testFromPayumOptionSuccess(): void
+    {
+        static::assertEquals(SignatureAlgorithm::SHA1, SignatureAlgorithm::fromPayumOption('algo-sha1'));
+        static::assertEquals(SignatureAlgorithm::HMAC_SHA256, SignatureAlgorithm::fromPayumOption('algo-hmac-sha256'));
+    }
+
+    public function testFromPayumOptionFailAlreadyPrefixedAlgo(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The prefix "algo-" is not present in passed algorithm "sha1".');
+
+        SignatureAlgorithm::fromPayumOption(SignatureAlgorithm::SHA1);
+    }
+
+    public function testFromPayumOptionFailWithUnknownAlgo(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown algorithm "foobar".');
+
+        SignatureAlgorithm::fromPayumOption('algo-foobar');
+    }
+}


### PR DESCRIPTION
BREAKING CHANGE:
Constant `Yproximite\Payum\SystemPay\SignatureGenerator::HASH_ALGORITHM_PREFIX` does not exist anymore, use `Yproximite\Payum\SystemPaym\SignatureAlgorithm::toPayumOption(string $algo)` instead.